### PR TITLE
Add ability to set custom domain in the admin settings

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,0 +1,62 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function simpleanalytics_warn_not_logging() {
+	echo "<!-- Simple Analytics: Not logging requests from admins -->\n";
+}
+
+function simpleanalytics_add_settings_page() {
+	add_options_page(
+		__( 'Simple Analytics Settings', 'simple-analytics' ),
+		__( 'Simple Analytics', 'simple-analytics' ),
+		'manage_options',
+		'simple-analytics-settings',
+		'simpleanalytics_render_settings_page'
+	);
+}
+
+function simpleanalytics_render_settings_page() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	$custom_domain = get_option( 'simpleanalytics_custom_domain' );
+
+	if ( isset( $_POST['simpleanalytics_custom_domain'] ) ) {
+		$custom_domain = sanitize_text_field( $_POST['simpleanalytics_custom_domain'] );
+		$custom_domain = preg_replace( '/^https?:\/\//', '', $custom_domain );
+
+		update_option( 'simpleanalytics_custom_domain', $custom_domain );
+	}
+	?>
+    <div class="wrap">
+        <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+        <form method="post"
+              action="<?php echo esc_url( admin_url( 'options-general.php?page=simple-analytics-settings' ) ); ?>">
+			<?php wp_nonce_field( 'simpleanalytics_settings', 'simpleanalytics_settings_nonce' ); ?>
+            <table class="form-table">
+                <tbody>
+                <tr>
+                    <th scope="row">
+                        <label for="simpleanalytics_custom_domain"><?php esc_html_e( 'Custom Analytics Domain', 'simple-analytics' ); ?></label>
+                    </th>
+                    <td>
+                        <input type="text" name="simpleanalytics_custom_domain" id="simpleanalytics_custom_domain"
+                               value="<?php echo esc_attr( $custom_domain ); ?>" class="regular-text">
+                        <p class="description"><?php esc_html_e( 'Enter your custom analytics domain (e.g., api.example.com). Leave empty to use the default domain.', 'simple-analytics' ); ?></p>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+			<?php submit_button( __( 'Save Changes', 'simple-analytics' ) ); ?>
+        </form>
+    </div>
+	<?php
+}
+
+add_action( 'admin_menu', 'simpleanalytics_add_settings_page' );
+wp_enqueue_script( 'simpleanalytics_admins', plugins_url( 'public/js/admins.js', dirname( __FILE__ ) ), array(), null, true );
+add_action( 'wp_footer', 'simpleanalytics_warn_not_logging', 10 );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -32,12 +32,14 @@ function simpleanalytics_render_settings_page() {
 			return;
 		}
 
-		if ( isset( $_POST['simpleanalytics_custom_domain'] ) ) {
-			$custom_domain = sanitize_text_field( $_POST['simpleanalytics_custom_domain'] );
-			$custom_domain = preg_replace( '/^https?:\/\//', '', $custom_domain );
-
-			update_option( 'simpleanalytics_custom_domain', $custom_domain );
+		if ( ! isset( $_POST['simpleanalytics_custom_domain'] ) ) {
+			return;
 		}
+
+		$custom_domain = sanitize_text_field( $_POST['simpleanalytics_custom_domain'] );
+		$custom_domain = preg_replace( '/^https?:\/\//', '', $custom_domain );
+
+		update_option( 'simpleanalytics_custom_domain', $custom_domain );
 	}
 
 	$custom_domain = get_option( 'simpleanalytics_custom_domain' );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -23,14 +23,24 @@ function simpleanalytics_render_settings_page() {
 		return;
 	}
 
-	$custom_domain = get_option( 'simpleanalytics_custom_domain' );
+	if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
+		if ( ! isset( $_POST['simpleanalytics_settings_nonce'] ) ) {
+			return;
+		}
 
-	if ( isset( $_POST['simpleanalytics_custom_domain'] ) ) {
-		$custom_domain = sanitize_text_field( $_POST['simpleanalytics_custom_domain'] );
-		$custom_domain = preg_replace( '/^https?:\/\//', '', $custom_domain );
+		if ( ! wp_verify_nonce( $_POST['simpleanalytics_settings_nonce'], 'simpleanalytics_settings' ) ) {
+			return;
+		}
 
-		update_option( 'simpleanalytics_custom_domain', $custom_domain );
+		if ( isset( $_POST['simpleanalytics_custom_domain'] ) ) {
+			$custom_domain = sanitize_text_field( $_POST['simpleanalytics_custom_domain'] );
+			$custom_domain = preg_replace( '/^https?:\/\//', '', $custom_domain );
+
+			update_option( 'simpleanalytics_custom_domain', $custom_domain );
+		}
 	}
+
+	$custom_domain = get_option( 'simpleanalytics_custom_domain' );
 	?>
     <div class="wrap">
         <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>

--- a/simple-analytics.php
+++ b/simple-analytics.php
@@ -17,28 +17,25 @@
  * @since 1.0.0
  */
 
-if (!defined('ABSPATH')) exit;
-
-$simpleanalytics_script = 'https://scripts.simpleanalyticscdn.com/latest.js';
-
-function simpleanalytics_warn_not_logging() {
-  echo "<!-- Simple Analytics: Not logging requests from admins -->\n";
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 function simpleanalytics_noscript() {
-  echo '<noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"></noscript>' . "\n";
+	$domain = get_option( 'simpleanalytics_custom_domain' ) ?: 'queue.simpleanalyticscdn.com';
+
+	echo '<noscript><img src="https://' . $domain . '/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"></noscript>' . "\n";
 }
 
 function simpleanalytics_init() {
-  global $simpleanalytics_script;
-  $is_running = !current_user_can('editor') && !current_user_can('administrator');
-  if ($is_running) {
-    wp_enqueue_script('simpleanalytics_script', $simpleanalytics_script, array(), null, true);
-    add_action('wp_footer', 'simpleanalytics_noscript', 10);
-  } else {
-    wp_enqueue_script('simpleanalytics_admins', plugins_url('public/js/admins.js', __FILE__), array(), null, true);
-    add_action('wp_footer', 'simpleanalytics_warn_not_logging', 10);
-  }
+	if ( current_user_can( 'editor' ) || current_user_can( 'administrator' ) ) {
+		require_once plugin_dir_path( __FILE__ ) . 'includes/admin.php';
+	} else {
+		$domain = get_option( 'simpleanalytics_custom_domain' ) ?: 'scripts.simpleanalyticscdn.com';
+
+		wp_enqueue_script( 'simpleanalytics_script', "https://$domain/latest.js", array(), null, true );
+		add_action( 'wp_footer', 'simpleanalytics_noscript', 10 );
+	}
 }
 
-add_action('init', 'simpleanalytics_init');
+add_action( 'init', 'simpleanalytics_init' );


### PR DESCRIPTION
- Moved the admin script and footer comment registration into the `includes/admin.php` file
- Added the ability to set a custom domain via the settings page in the admin panel (in `includes/admin.php`)
- Switched to the official WordPress code style

<img width="1101" alt="image" src="https://github.com/simpleanalytics/wordpress-plugin/assets/23292709/33e3b73d-1cce-4e29-aff7-6f182ea95f87">
