### PR TITLE
Remove "Enabled" checkbox

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -99,10 +99,6 @@ final class Plugin
                     ->placeholder('Enter your custom domain or leave it empty.')
                     ->description('E.g. api.example.com. Leave empty to use the default domain (most users).')
                     ->docs('https://docs.simpleanalytics.com/bypass-ad-blockers');
-
-                $tab->checkbox(SettingName::ENABLED, 'Enabled')
-                    ->default(true)
-                    ->description('Enable or disable Simple Analytics on your website.');
             })
             ->tab('Ignore Rules', function (Tab $tab) {
                 $tab->icon(get_icon('eye-slash'));

--- a/src/TrackingPolicy.php
+++ b/src/TrackingPolicy.php
@@ -6,10 +6,6 @@ class TrackingPolicy
 {
     public function shouldCollectAnalytics(): bool
     {
-        if (Setting::boolean(SettingName::ENABLED, true) === false) {
-            return false;
-        }
-
         if ($this->clientIpExcluded($_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'])) {
             return false;
         }


### PR DESCRIPTION
Users can already deactivate the plugin from within the WordPress "Plugins" page, thus making this option unnecessary.