### PR TITLE
Add wordpress platform marker to script tag

### DIFF
--- a/src/Scripts/AnalyticsScript.php
+++ b/src/Scripts/AnalyticsScript.php
@@ -23,6 +23,7 @@ class AnalyticsScript implements Script, HasAttributes, HideScriptId
     public function attributes(): array
     {
         return array_filter([
+            'data-platform'     => 'wordpress',
             'data-mode'         => Setting::boolean(SettingName::HASH_MODE) ? 'hash' : null,
             'data-collect-dnt'  => Setting::boolean(SettingName::COLLECT_DNT) ? 'true' : null,
             'data-ignore-pages' => Setting::get(SettingName::IGNORE_PAGES),

--- a/tests/Browser/pluginSettings.spec.ts
+++ b/tests/Browser/pluginSettings.spec.ts
@@ -42,6 +42,7 @@ test('adds a script by default', async ({ page, browser }) => {
 
   const guest = await visitAsGuest(browser);
   await expect(guest.locator(DEFAULT_SCRIPT_SELECTOR)).toBeAttached();
+  expect(await guest.content()).toContain('data-platform="wordpress"');
   await guest.context().close();
 });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/simpleanalytics/wordpress-plugin/issues/20

Adds `data-platform="wordpress"` to the Simple Analytics script tag so WordPress plugin traffic can be identified by platform. Also adds a browser test assertion to prevent regressions.

## Security implications

- [x] No security impact
- [ ] Has security impact - described as:

## Testing

- Ran Local tests & verified the rendered page includes `data-platform="wordpress"` on the analytics script tag
- Ran `pnpm playwright test tests/Browser/pluginSettings.spec.ts --grep "adds a script by default"`

## Checklist

- [x] Linked to an issue
- [x] Tested
- [x] Asked for a review