### PR TITLE
Improve e2e workflow reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,15 @@ jobs:
             - name: Install pnpm dependencies
               run: pnpm install
 
+            - name: Restore Playwright browsers cache
+              id: playwright-cache
+              uses: actions/cache/restore@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-playwright-
+
             - name: Set WordPress and PHP version override
               run: |
                   echo '{
@@ -71,8 +80,39 @@ jobs:
             - name: Start wp-env
               run: pnpm exec wp-env start
 
-            - name: Install Playwright browsers
-              run: pnpm run tests:install
+            - name: Verify WordPress login page
+              run: |
+                  for attempt in {1..10}; do
+                    if curl -fsS http://localhost:8888/wp-login.php | grep -q 'id="user_login"'; then
+                      exit 0
+                    fi
+                    sleep 3
+                  done
+
+                  curl -fsS http://localhost:8888/wp-login.php || true
+                  exit 1
+
+            - name: Use Ubuntu archive mirror
+              run: |
+                  if [ -f /etc/apt/apt-mirrors.txt ]; then
+                    sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+                  fi
+                  if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+                    sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+                  fi
+                  sudo apt-get update
+
+            - name: Install Playwright
+              timeout-minutes: 5
+              run: pnpm exec playwright install --with-deps chromium
+
+            - name: Save Playwright browsers cache
+              if: steps.playwright-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v5
+              continue-on-error: true
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
 
             - name: Run Playwright tests
               run: pnpm exec playwright test


### PR DESCRIPTION
## Summary

This PR further improves E2E workflow reliability and speed.

Fixes https://github.com/simpleanalytics/wordpress-plugin/issues/34

### 1. Playwright browser caching

E2E runs were repeatedly downloading Playwright browsers, which made CI slower and more prone to transient download failures.

**Fix:** Added Playwright browser caching so repeated runs can reuse downloaded browsers.

### 2. Azure archive mirror timeouts

Ubuntu package downloads from the Azure archive mirror sometimes time out during Playwright dependency installation.

**Fix:** Switched CI package downloads to the main Ubuntu archive mirror. This is a bit hacky, but it appears to be much faster and more reliable.

### 3. WordPress readiness check

`wp-env start` does not always mean WordPress is fully ready before tests continue.

**Fix:** Added a WordPress login page check before installing Playwright and running tests.

---

## Security implications

- [x] No meaningful security impact. The cache only stores Playwright browser binaries and is keyed by `pnpm-lock.yaml`.
- [ ] Has security impact - described as:

---

## Testing

- Verified workflow changes
- Triggered GitHub Actions E2E tests

---

## Checklist

- [x] Linked to an issue
- [x] Tested
- [x] Asked for a review