### PR TITLE
Fix missing REMOTE_ADDR fallback in tracking rules.

### DIFF
--- a/src/TrackingRules.php
+++ b/src/TrackingRules.php
@@ -13,7 +13,7 @@ class TrackingRules
 
     public function hasExcludedIp(): bool
     {
-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'];
+        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? ($_SERVER['REMOTE_ADDR'] ?? null);
 
         if (empty($ip)) return false;
 


### PR DESCRIPTION
Prevent undefined array key warnings by safely defaulting to null.

## Summary

Closes #19

Updates the excluded IP tracking rule so `REMOTE_ADDR` safely falls back to `null` when neither `HTTP_X_FORWARDED_FOR` nor `REMOTE_ADDR` is available. This prevents PHP undefined array key warnings while preserving the existing behavior of returning `false` when no IP address is present.

## Security implications

- [x] No security impact
- [ ] Has security impact - described as:

## Testing

Manually reviewed and confirmed the fallback now avoids reading an undefined `REMOTE_ADDR` key. 

## Checklist

- [x] Linked to an issue
- [x] Tested
- [x] Asked for a review
